### PR TITLE
Update uniform_slide contour plot to auto adjust color range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 # Change-Log
 
 
+### 2025/02/25
+* Minor improvements to uniform slide plotting function to auto adjust its color range. Sumiya Kuroda [#91](https://github.com/SWC-Advanced-Microscopy/multiphoton-qc/issues/91).
+
+
 ### 2025/02/24
 * BUGFIX: correctly display photon counts in lens paper data where multiple channels were acquired at once.
 * BUGFIX: if weighted fit fails do a Huber fit.

--- a/code/+mpqc/+plot/uniform_slide.m
+++ b/code/+mpqc/+plot/uniform_slide.m
@@ -65,8 +65,15 @@ function uniform_slide(fname,varargin)
 
     hold on
     nContours = 10;
-    contour(plotData,nContours,'Color',[0.95,0.95,1],'linewidth',1)
-    colormap(gray(nContours+1))
+    colThreshold = 0.6;
+    contourf(plotData, nContours, 'LineColor', 'none');
+    if median(plotData(:)/max(plotData(:))) > colThreshold
+        caxis([0,colThreshold*max(plotData(:))])
+    else
+        caxis([0, max(plotData(:))])
+    end
+    color_tmp = gray(nContours+2);
+    colormap(color_tmp(1:end-1,:)) % use grayscale wuthout white
 
 
     % Add diagonal lines which we will use later to associate with the next plot


### PR DESCRIPTION
Right now, the code adjusts the color range with the following if-else conditions:

>     if median(plotData(:)/max(plotData(:))) > colThreshold
>         caxis([0,colThreshold*max(plotData(:))])
>     else
>         caxis([0, max(plotData(:))])
>     end

Fix #91 