### PR TITLE
Minor bug fix on type mismatch

### DIFF
--- a/code/+mpqc/+tools/reapplyScanImageSettings.m
+++ b/code/+mpqc/+tools/reapplyScanImageSettings.m
@@ -41,7 +41,7 @@ function settings = reapplyScanImageSettings(API,settings,verbose)
         API.hSI.hStackManager.slowStackWithFastZ = settings.stackManSlowFastZ;
     end
 
-    if API.versionGreaterThan(2023.0)
+    if API.versionGreaterThan('2023.0')
         API.hSI.hBeams.turnAroundBlanking = settings.turnAroundBlanking;
     end
     API.hSI.hBeams.flybackBlanking = settings.flybackBlanking;

--- a/code/+mpqc/+tools/recordScanImageSettings.m
+++ b/code/+mpqc/+tools/recordScanImageSettings.m
@@ -32,7 +32,7 @@ function settings = recordScanImageSettings(API)
     end
 
 
-    if API.versionGreaterThan(2023.0)
+    if API.versionGreaterThan('2023.0')
         settings.turnAroundBlanking = API.hSI.hBeams.turnAroundBlanking;
     end
     settings.flybackBlanking = API.hSI.hBeams.flybackBlanking;


### PR DESCRIPTION
Changed type of ScanImage version to char so that `versionGreaterThan()` works and it is consistent with other lines. Tested with ScanImage 2023.1.0. This fix https://github.com/SWC-Advanced-Microscopy/multiphoton-qc/issues/139